### PR TITLE
Consolidate dependabot PRs so CI will run

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,7 @@ repos:
         language_version: python3.10
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.2
+    rev: v3.0.0-alpha.3
     hooks:
       - id: prettier
         types_or: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
   # Update a bunch of Python syntax, using __futures__ for Python 3.8/3.9
   # Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.0.0
+    rev: v3.1.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
@@ -71,7 +71,7 @@ repos:
         language_version: python3.10
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.1
+    rev: v3.0.0-alpha.2
     hooks:
       - id: prettier
         types_or: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
   # Update a bunch of Python syntax, using __futures__ for Python 3.8/3.9
   # Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
+    rev: v2.38.2
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,20 +58,20 @@ repos:
   # Update a bunch of Python syntax, using __futures__ for Python 3.8/3.9
   # Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.2
+    rev: v3.0.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]
 
   # Deterministic python formatting:
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3.10
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.0
+    rev: v3.0.0-alpha.1
     hooks:
       - id: prettier
         types_or: [yaml]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
   # Update a bunch of Python syntax, using __futures__ for Python 3.8/3.9
   # Note that this sometimes conflicts with Pydantic on Python 3.8/3.9
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v2.38.0
     hooks:
       - id: pyupgrade
         args: ["--py38-plus"]

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         "pytest~=7.1.1",
         "pg8000~=1.29.1",
         "google-cloud-storage~=2.4.0",
-        "cloud-sql-python-connector[pg8000]>=0.6.2,<0.8.0",
+        "cloud-sql-python-connector[pg8000]>=0.6.2,<1.2.0",
     ],
     extras_require={
         "dev": [


### PR DESCRIPTION
As in #90 - dependabot PRs are failing because they can't get secrets because they're treated as external PRs full of untrusted code.

But if I, a human being who is within the organization, pushes the same changes, CI should run just fine. And if that passes we'll merge.