### PR TITLE
Use WIF for tox-pytest and load-metrics workflows

### DIFF
--- a/.github/workflows/load-metrics.yml
+++ b/.github/workflows/load-metrics.yml
@@ -3,7 +3,7 @@ name: load-metrics
 on:
   workflow_dispatch:
   schedule:
-    - cron: "15 0 * * *" # Every day at 12:15 AM UTC
+    - cron: "14 0 * * *" # Every day at 12:14 AM UTC
 
 env:
   PRESET_IP1: 44.193.153.196
@@ -13,6 +13,9 @@ env:
 jobs:
   load-metrics:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v3
         with:
@@ -22,7 +25,9 @@ jobs:
       - id: "auth"
         uses: "google-github-actions/auth@v1"
         with:
-          credentials_json: "${{ secrets.GCP_SA_KEY }}"
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+          create_credentials_file: true
 
       - name: Set up conda environment for testing
         uses: conda-incubator/setup-miniconda@v2.2.0

--- a/.github/workflows/load-metrics.yml
+++ b/.github/workflows/load-metrics.yml
@@ -26,7 +26,7 @@ jobs:
         uses: "google-github-actions/auth@v1"
         with:
           workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
-          service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+          service_account: "pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
           create_credentials_file: true
 
       - name: Set up conda environment for testing

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -5,6 +5,9 @@ on: [push, pull_request]
 jobs:
   ci-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
 
@@ -33,11 +36,13 @@ jobs:
           conda config --show
           printenv | sort
 
-      # Authentication via credentials json
       - name: Authenticate gcloud
         uses: "google-github-actions/auth@v1"
+        continue-on-error: true
         with:
-          credentials_json: "${{ secrets.GCP_SA_KEY }}"
+          workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
+          service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+          create_credentials_file: true
 
       - name: Run pytest
         env:
@@ -60,6 +65,7 @@ jobs:
     steps:
       - name: Inform the Codemonkeys
         uses: 8398a7/action-slack@v3
+        continue-on-error: true
         with:
           status: custom
           fields: workflow,job,commit,repo,ref,author,took

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -38,7 +38,6 @@ jobs:
 
       - name: Authenticate gcloud
         uses: "google-github-actions/auth@v1"
-        continue-on-error: true
         with:
           workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
           service_account: "pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"

--- a/.github/workflows/tox-pytest.yml
+++ b/.github/workflows/tox-pytest.yml
@@ -41,7 +41,7 @@ jobs:
         continue-on-error: true
         with:
           workload_identity_provider: "projects/345950277072/locations/global/workloadIdentityPools/gh-actions-pool/providers/gh-actions-provider"
-          service_account: "tox-pytest-github-action@catalyst-cooperative-pudl.iam.gserviceaccount.com"
+          service_account: "pudl-usage-metrics-etl@catalyst-cooperative-pudl.iam.gserviceaccount.com"
           create_credentials_file: true
 
       - name: Run pytest


### PR DESCRIPTION
This should move us one step closer to not needing credentials jsons floating around, and maybe even lets us merge bot PRs automatically.

`tox-pytest` has some continue-on-error stuff in the hopes that that alleviates issues with external PRs, but `load-metrics` will only be run internally so I'm not concerned about that.