### PR TITLE
Add s3 bucket script and notebook

### DIFF
--- a/notebooks/analyze_s3_logs.py
+++ b/notebooks/analyze_s3_logs.py
@@ -1,0 +1,27 @@
+"""Script for downloading all s3://pudl.catalyst.coop logs from a GCS bucket."""
+
+import os
+
+from google.cloud import storage
+from tqdm import tqdm
+
+
+def download_logs_from_gcs(bucket_uri: str, local_dir: str):
+    """
+    Download all logs from GCS bucket.
+
+    If the file already exists locally don't download it.
+    """
+    bucket = storage.Client().get_bucket(bucket_uri)
+    blobs = bucket.list_blobs()
+    for blob in tqdm(blobs):
+        if not os.path.exists(os.path.join(local_dir, blob.name)):
+            blob.download_to_filename(os.path.join(local_dir, blob.name))
+        else:
+            print(f"File {blob.name} already exists locally. Skipping download.")
+
+
+if __name__ == "__main__":
+    bucket_uri = "pudl-s3-logs.catalyst.coop"
+    local_dir = "data/pudl_s3_logs/"
+    download_logs_from_gcs(bucket_uri, local_dir)

--- a/notebooks/datasette_analysis.ipynb
+++ b/notebooks/datasette_analysis.ipynb
@@ -302,7 +302,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,

--- a/notebooks/quick-s3-logs-analysis.ipynb
+++ b/notebooks/quick-s3-logs-analysis.ipynb
@@ -1,0 +1,371 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0336c89-6e7e-45c1-84f9-295aefcc9349",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from pathlib import Path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "91070639-342b-4a03-8f96-18ce77f60f81",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from usage_metrics.ops.datasette import geocode_ips"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9aa38b78-a1d2-4158-9608-e38b7612ceec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_dir = Path(\"../data/pudl_s3_logs/\").resolve()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba31c443-ef9c-405c-bbcf-b3f890d5451a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from tqdm import tqdm\n",
+    "\n",
+    "dfs = []\n",
+    "\n",
+    "for filepath in tqdm(local_dir.glob('*')):\n",
+    "    # print(f\"Reading file: {filepath}\")\n",
+    "    dfs.append(pd.read_csv(filepath, delimiter=\" \", header=None))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fb91e2ab-d42e-492e-adf6-9e97aca94557",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.concat(dfs)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f36aa7f0-8894-4c4c-9772-e0c49619ca1f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.set_option('display.max_columns', None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "918b691d-e038-41b5-848e-1efa2205382f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df[2] = df[2] + \" \" + df[3]\n",
+    "df = df.drop(columns=[3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "214e9efd-513d-443e-809d-86da09892f74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "field_names = [\n",
+    "    'bucket_owner',\n",
+    "    'bucket',\n",
+    "    'time',\n",
+    "    'remote_ip',\n",
+    "    'requester',\n",
+    "    'request_id',\n",
+    "    'operation',\n",
+    "    'key',\n",
+    "    'request_uri',\n",
+    "    'http_status',\n",
+    "    'error_code',\n",
+    "    'bytes_sent',\n",
+    "    'object_size',\n",
+    "    'total_time',\n",
+    "    'turn_around_time',\n",
+    "    'referer',\n",
+    "    'user_agent',\n",
+    "    'version_id',\n",
+    "    'host_id',\n",
+    "    'signature_version',\n",
+    "    'cipher_suite',\n",
+    "    'authentication_type',\n",
+    "    'host_header',\n",
+    "    'tls_version',\n",
+    "    'access_point_arn',\n",
+    "    'acl_required'\n",
+    "]\n",
+    "\n",
+    "df.columns = field_names\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55109d6d-aa95-4002-9a0b-64795b2a7b6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.remote_ip.eq(\"-\").value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "00d76ed1-62f7-4ee9-90e4-f84bc696c730",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.remote_ip.nunique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f36e74ad-418f-4991-9400-4b45c3224c7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dagster import build_op_context\n",
+    "\n",
+    "df[\"remote_ip\"] = df[\"remote_ip\"].mask(df[\"remote_ip\"].eq(\"-\"), pd.NA)\n",
+    "\n",
+    "context = build_op_context()\n",
+    "geocoded_df = geocode_ips(context, df)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf40d378-695a-4687-85c9-8e3d6bb2faaa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded_df[geocoded_df.remote_ip_org.str.contains(\"University|College|Institute\", na=False)].remote_ip_org.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6557ee3b-bead-45c8-ac8e-93fb2bb2532a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded_df.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dd70fcf6-939b-4277-9348-fd95d7bc42e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "format_string = '[%d/%b/%Y:%H:%M:%S %z]'\n",
+    "\n",
+    "# Convert string to datetime using Pandas\n",
+    "geocoded_df[\"timestamp\"] = pd.to_datetime(geocoded_df.time, format=format_string)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c5b7aba4-e203-4937-9cc5-d59af9366b0d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded_df.groupby(pd.Grouper(key='timestamp', freq='M')).remote_ip.nunique().plot.bar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d2609629-8b58-4429-9120-27ec9ed4072f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8757ded-ac97-4f9d-a8f0-92ec610daef9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded_df.operation.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "05656d08-f7c1-44b6-8773-b81a029637fd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "geocoded_df.operation.str.contains(\"REST.GET\").value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5614479b-32f3-4420-abd9-37b2c7beddcb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gets = geocoded_df[geocoded_df.operation.str.contains(\"REST.GET\")]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41f662d5-f453-44a2-a1c3-94d05296d41c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gets[\"bytes_sent\"].eq(\"-\").value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b73d214-4683-4ee8-b28f-c4241a1493cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gets[\"bytes_sent\"] = gets[\"bytes_sent\"].mask(gets[\"bytes_sent\"].eq(\"-\"), 0)\n",
+    "gets[\"bytes_sent\"].eq(\"-\").value_counts()\n",
+    "gets = gets.convert_dtypes()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb9af5bc-a1ed-46b5-bdde-051775ffbece",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gets.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3f56e99a-9551-430b-9e48-eff687b08528",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gets.groupby(pd.Grouper(key='timestamp', freq='M')).bytes_sent.sum().div(1024 ** 3).plot.bar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f4dde30-efd4-41ab-be10-392a050568a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gets = gets.drop(columns=[\"time\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcba5a1e-e686-42a4-9412-a2058c9b92bc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "numeric_fields = [\"bytes_sent\", \"http_status\", \"object_size\", \"total_time\", \"turn_around_time\"]\n",
+    "for field in numeric_fields:\n",
+    "    gets[field] = pd.to_numeric(gets[field], errors='coerce')\n",
+    "\n",
+    "gets.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da7f3da0-ef88-415e-a20d-133cf96b89b6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_ips = gets.groupby(pd.Grouper(key='timestamp', freq='M')).remote_ip.nunique()\n",
+    "\n",
+    "monthly_ips.plot.bar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ab1e7ba-8edf-4643-8997-b23ee143b5aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_ips.describe()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6d18b1ad-5504-420f-9f7f-8522e34c8180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_gbs = gets.groupby(pd.Grouper(key='timestamp', freq='M')).bytes_sent.sum().div(1024 ** 3)\n",
+    "\n",
+    "monthly_ips.plot.bar()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f294100b-c77d-4a95-83f0-6e0e3d901107",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_gbs.describe()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/setup.py
+++ b/setup.py
@@ -26,11 +26,14 @@ setup(
     # In order for the dependabot to update versions, they must be listed here.
     # Use the format package_name>=x,<y", Included packages are just examples:
     install_requires=[
+        "google-cloud-storage>=2.14",
+        "tqdm>=4.66",
         "pandas>=1.4,<1.5",
         "sqlalchemy>=1.4,<2",
         "dagster~=0.15.0",
         "dagit~=0.15.0",
         "dagster-pandera~=0.15.0",
+        "pendulum<3.0",
         "pandas-gbq~=0.17.0",
         "pydata-google-auth>=1.3,<1.5",
         "jupyterlab>=3.2.8,<3.5.0",

--- a/src/usage_metrics/ops/datasette.py
+++ b/src/usage_metrics/ops/datasette.py
@@ -165,9 +165,9 @@ def geocode_ips(context, df: pd.DataFrame) -> pd.DataFrame:
         geocoded_logs: logs with ip location info columns.
     """
     # Geocode the remote ip addresses
-    context.log.info("Geocoding ip addresses.")
     # Instead of geocoding every log, geocode the distinct ips
-    unique_ips = pd.Series(df.remote_ip.unique())
+    unique_ips = pd.Series(df.remote_ip.unique()).dropna()
+    context.log.info(f"Geocoding {len(unique_ips)} ip addresses.")
     geocoded_ips = unique_ips.apply(lambda ip: geocode_ip(ip))
     geocoded_ips = pd.DataFrame.from_dict(geocoded_ips.to_dict(), orient="index")
     geocoded_ip_column_map = {


### PR DESCRIPTION
This PR contains a script that downloads our s3 logs and a notebook that does some cleaning and geocoding of the logs. I've been using this janky setup for when people request stats about the usage because we haven't had time to properly integrate it into our usage metrics pipeline. 