### PR TITLE
Switch from daily to weekly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,10 +6,10 @@ updates:
     labels:
       - "dependencies"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
# Overview

Switch to weekly dependency updates to reduce notification chatter.

# Testing

I wasn't actually able to create the conda environment for this locally (on MacOS), and so the tests weren't run. `pip` failed  with an error about postgres:

<details>

```
Retrieving notices: ...working... done
Channels:
 - conda-forge
 - defaults
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: done

Downloading and Extracting Packages:

Preparing transaction: done
Verifying transaction: done
Executing transaction: done
Installing pip dependencies: \ Ran pip subprocess with arguments:
['/Users/zane/miniforge3/envs/pudl-usage-metrics/bin/python', '-m', 'pip', 'install', '-U', '-r', '/Users/zane/code/catalyst/pudl-usage-metrics/condaenv.55rjxihz.requirements.txt', '--exists-action=b']
Pip subprocess output:
Obtaining file:///Users/zane/code/catalyst/pudl-usage-metrics
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Collecting pandas<2.3,>=2.2 (from pudl_usage_metrics==0.1.0)
  Using cached pandas-2.2.2-cp312-cp312-macosx_11_0_arm64.whl.metadata (19 kB)
Collecting sqlalchemy>=2 (from pudl_usage_metrics==0.1.0)
  Using cached SQLAlchemy-2.0.31-cp312-cp312-macosx_11_0_arm64.whl.metadata (9.6 kB)
Collecting dagster<1.7.13,>=1.7 (from pudl_usage_metrics==0.1.0)
  Downloading dagster-1.7.12-py3-none-any.whl.metadata (12 kB)
Collecting pandas-gbq>=0.23.1 (from pudl_usage_metrics==0.1.0)
  Downloading pandas_gbq-0.23.1-py2.py3-none-any.whl.metadata (3.4 kB)
Collecting pydata-google-auth>=1.8.2 (from pudl_usage_metrics==0.1.0)
  Using cached pydata_google_auth-1.8.2-py2.py3-none-any.whl.metadata (3.2 kB)
Collecting jupyterlab>=4.2.3 (from pudl_usage_metrics==0.1.0)
  Downloading jupyterlab-4.2.4-py3-none-any.whl.metadata (16 kB)
Collecting psycopg2>=2.9.9 (from pudl_usage_metrics==0.1.0)
  Downloading psycopg2-2.9.9.tar.gz (384 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 384.9/384.9 kB 743.1 kB/s eta 0:00:00
  Preparing metadata (setup.py): started
  Preparing metadata (setup.py): finished with status 'error'

Pip subprocess error:
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      running egg_info
      creating /private/var/folders/ps/6jyqvztj5fq_tvhwx5h59d7w0000z8/T/pip-pip-egg-info-yhhsli1a/psycopg2.egg-info
      writing /private/var/folders/ps/6jyqvztj5fq_tvhwx5h59d7w0000z8/T/pip-pip-egg-info-yhhsli1a/psycopg2.egg-info/PKG-INFO
      writing dependency_links to /private/var/folders/ps/6jyqvztj5fq_tvhwx5h59d7w0000z8/T/pip-pip-egg-info-yhhsli1a/psycopg2.egg-info/dependency_links.txt
      writing top-level names to /private/var/folders/ps/6jyqvztj5fq_tvhwx5h59d7w0000z8/T/pip-pip-egg-info-yhhsli1a/psycopg2.egg-info/top_level.txt
      writing manifest file '/private/var/folders/ps/6jyqvztj5fq_tvhwx5h59d7w0000z8/T/pip-pip-egg-info-yhhsli1a/psycopg2.egg-info/SOURCES.txt'

      Error: pg_config executable not found.

      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:

          python setup.py build_ext --pg-config /path/to/pg_config build ...

      or with the pg_config option in 'setup.cfg'.

      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.

      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).

      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.

failed

CondaEnvException: Pip failed
```

</details>