### PR TITLE
Fix `save_daily_metrics.yml` import error

### DIFF
--- a/src/usage_metrics/helpers.py
+++ b/src/usage_metrics/helpers.py
@@ -5,12 +5,10 @@ from __future__ import annotations
 import os
 from datetime import UTC, datetime, timezone
 from pathlib import Path
-from urllib.error import HTTPError
 from urllib.parse import urlparse
 
 import ipinfo
 import pandas as pd
-import requests
 from dagster import OutputContext, RetryPolicy, op
 from joblib import Memory
 
@@ -156,28 +154,3 @@ def get_table_name_from_context(context: OutputContext) -> str:
     if context.has_asset_key:
         return context.asset_key.to_python_identifier()
     return context.get_identifier()
-
-
-def make_request(
-    url: str, headers: str | None = None, params: str | None = None, timeout: int = 100
-) -> requests.models.Response:
-    """Makes a request with some error handling.
-
-    Args:
-        query (str): A request url.
-        headers (str): Header to include in the request.
-        params (str): Params of request.
-        timeout (int): Timeout of request (in seconds).
-
-    Returns:
-        response (requests.models.Response): the request response.
-    """
-    try:
-        response = requests.get(url, headers=headers, params=params, timeout=timeout)
-
-        response.raise_for_status()
-    except HTTPError as http_err:
-        raise HTTPError(
-            f"HTTP error occurred: {http_err}\n\tResponse text: {response.text}"
-        )
-    return response

--- a/src/usage_metrics/scripts/save_github_metrics.py
+++ b/src/usage_metrics/scripts/save_github_metrics.py
@@ -8,9 +8,8 @@ import time
 from dataclasses import dataclass
 from datetime import date
 
+import requests
 from google.cloud import storage
-
-from usage_metrics.helpers import make_request
 
 logger = logging.getLogger()
 logging.basicConfig(level="INFO")
@@ -39,7 +38,7 @@ def get_biweekly_metrics(owner: str, repo: str, token: str, metric: str) -> str:
         "Accept": "application/vnd.github.v3+json",
     }
 
-    response = make_request(url=url, headers=headers)
+    response = requests.get(url, headers=headers, timeout=100)
     return json.dumps(response.json())
 
 
@@ -66,7 +65,9 @@ def get_persistent_metrics(owner: str, repo: str, token: str, metric: str) -> st
 
     while time.time() < timeout_start + timeout:
         params = {"page": page}
-        metrics_json = make_request(url=url, headers=headers, params=params).json()
+        metrics_json = requests.get(
+            url=url, headers=headers, params=params, timeout=100
+        ).json()
 
         if len(metrics_json) <= 0:
             break


### PR DESCRIPTION
# Overview

Closes #198.

What problem does this address?
Fixes an import error caused by the outdated `datasette` and `intake` jobs, which was caused by moving the `requests.get()` call to `helpers.py` in #187. This was masked by the micromamba failures for several days.

What did you change in this PR?
Reverted the change in #187, as it is not essential. The more thorough solution would be to deprecate the unneeded jobs, which we should do once datasette data is being ETL'd in #128. I made the change initially in order to facilitate eventually adding some retries to the get request. However, given that this is function basically glorified error message formatting at this point, I'd prefer to leave the datasette code as-is to inform the near-term ETL, and then revisit this question later.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `save_daily_metrics.yml`.

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
