### PR TITLE
Fix gcloud set up in `load-metrics.yml`

### DIFF
--- a/.github/workflows/load-metrics.yml
+++ b/.github/workflows/load-metrics.yml
@@ -51,7 +51,6 @@ jobs:
           version: ">= 363.0.0"
 
       - name: Whitelist Github Action and Superset IPs
-        shell: bash -l {0}
         run: |
           gcloud sql instances patch ${{ secrets.GCSQL_INSTANCE_NAME }} --authorized-networks=${{ steps.ip.outputs.ipv4 }}
 

--- a/.github/workflows/load-metrics.yml
+++ b/.github/workflows/load-metrics.yml
@@ -45,7 +45,13 @@ jobs:
         run: |
           echo ${{ steps.ip.outputs.ipv4 }}
 
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+        with:
+          version: ">= 363.0.0"
+
       - name: Whitelist Github Action and Superset IPs
+        shell: bash -l {0}
         run: |
           gcloud sql instances patch ${{ secrets.GCSQL_INSTANCE_NAME }} --authorized-networks=${{ steps.ip.outputs.ipv4 }}
 


### PR DESCRIPTION
# Overview

What problem does this address?
I'm not 100% sure what caused the issue, but the `load_metrics.yml` was suddenly having a problem authenticating gcloud (see, e.g. https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/11292667735).

What did you change in this PR?
Added a gcloud set up step mirroring the one used in `save_daily_metrics.yml`, and specified the shell running the `gcloud` command.

# Testing

How did you make sure this worked? How can a reviewer verify this?
See https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/11292842735.

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
