### PR TITLE
Drop NAs from IPs before geocoding

### DIFF
--- a/src/usage_metrics/helpers.py
+++ b/src/usage_metrics/helpers.py
@@ -58,7 +58,7 @@ def geocode_ips(df: pd.DataFrame) -> pd.DataFrame:
         geocoded_logs: dataframe with ip location info columns.
     """
     # Instead of geocoding every log, geocode the distinct ips
-    unique_ips = pd.Series(df.remote_ip.unique())
+    unique_ips = pd.Series(df.remote_ip.dropna().unique())
     geocoded_ips = unique_ips.apply(lambda ip: geocode_ip(ip))
     geocoded_ips = pd.DataFrame.from_dict(geocoded_ips.to_dict(), orient="index")
     geocoded_ip_column_map = {


### PR DESCRIPTION
# Overview

What problem does this address?
Fixes the build failure here: https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/11549171533

What did you change in this PR?
- I can't reproduce this error locally, but we shouldn't be trying to geocode NA values anyways, so we may as well `dropna()` before geocoding IPs.

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
