### PR TITLE
Update slack API to 2.0 format

### DIFF
--- a/.github/workflows/load-metrics.yml
+++ b/.github/workflows/load-metrics.yml
@@ -76,7 +76,8 @@ jobs:
         id: slack
         uses: slackapi/slack-github-action@v2
         with:
-          channel-id: "C03FHB9N0PQ"
-          slack-message: "Weekly usage metrics processing ran with status: ${{ job.status }}."
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+          method: chat.postMessage
+          token: ${{ secrets.PUDL_DEPLOY_SLACK_TOKEN }}
+          payload: |
+            text: "Weekly usage metrics processing ran with status: ${{ job.status }}."
+            channel: "C03FHB9N0PQ"


### PR DESCRIPTION
# Overview

What problem does this address?
Fixes failure of the last two weeks of `load_metrics` due to a Slackbot API change. See https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/12114518714

What did you change in this PR?
Updated the way we're passing the information in the GHA to be compliant with the new Slack API 2.0.

# Testing

How did you make sure this worked? How can a reviewer verify this?
See - https://catalystcooperative.slack.com/archives/C03FHB9N0PQ/p1733507587745689
# To-do list

```[tasklist]
- [ ] Review the PR yourself and call out any questions or issues you have
```
