### PR TITLE
Add `censuspep` dataset to Zenodo slugs

### DIFF
--- a/src/usage_metrics/core/zenodo.py
+++ b/src/usage_metrics/core/zenodo.py
@@ -111,7 +111,7 @@ def core_zenodo_logs(
         "3653158": "pudl_data_release",
         "3404014": "pudl_code",
         "10020145": "ferc_xbrl_extractor",
-        "14624612": "censuspep",
+        "14624611": "censuspep",
     }
 
     missed_mapping = df[

--- a/src/usage_metrics/core/zenodo.py
+++ b/src/usage_metrics/core/zenodo.py
@@ -111,6 +111,7 @@ def core_zenodo_logs(
         "3653158": "pudl_data_release",
         "3404014": "pudl_code",
         "10020145": "ferc_xbrl_extractor",
+        "14624612": "censuspep",
     }
 
     missed_mapping = df[


### PR DESCRIPTION
# Overview

What problem does this address?
Fixes failed `load_metrics.yml` [run](https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/12862927647)

What did you change in this PR?
Added `censuspep` concept DOI to slug mapping. People are downloading our newest dataset!

# Testing

How did you make sure this worked? How can a reviewer verify this?
Rerun `load_metrics.yml`: https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/12873081270

# To-do list

```[tasklist]
- [x] Review the PR yourself and call out any questions or issues you have
```
