### PR TITLE
Add ipinfo token instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ mamba activate pudl-usage-metrics
 
 ## Environment Variables
 
-The ETL uses [ipinfo](https://ipinfo.io/) to geocode ip addresses. You need to obtain an ipinfo API token and store it in the `IPINFO_TOKEN` environment variable.
+The ETL uses [ipinfo](https://ipinfo.io/) to geocode ip addresses. Grab the [ipinfo token](https://ipinfo.io/account/token) by logging in using the credentials saved in our [Bitwarden Shared Inframundo Logins collection](https://vault.bitwarden.com/#/vault?collectionId=b53a14cf-48bd-4b53-a59e-b29600217e8b&itemId=50afdcf5-8cec-42a3-b366-b296013ba389&action=view).  `IPINFO_TOKEN` environment variable.
 
 If you want to take advantage of caching raw logs, rather than redownloading them for each run, you can set the optional ``DATA_DIR`` environment variable. If this is not set, the script will save files to a temporary directory by default.
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Now that we have a password manager I created a shared login for ipinfo.io. This PR adds instructions on how to grab the ipinfo token.

Questions: would be simpler to just add the token to Google Secrets?

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
