### PR TITLE
Raise error when Github API fails

### DIFF
--- a/src/usage_metrics/scripts/save_github_metrics.py
+++ b/src/usage_metrics/scripts/save_github_metrics.py
@@ -39,7 +39,15 @@ def get_biweekly_metrics(owner: str, repo: str, token: str, metric: str) -> str:
     }
 
     response = requests.get(url, headers=headers, timeout=100)
-    return json.dumps(response.json())
+    response_json = response.json()
+    if response.status != 200 or response_json.get("status") not in (
+        None,
+        "200",
+    ):  # If status returned by API, raise error.
+        raise ValueError(
+            f"Github API for {metric} returning status {response_json.get('status')}. See URL {url}"
+        )
+    return json.dumps(response_json)
 
 
 def get_persistent_metrics(owner: str, repo: str, token: str, metric: str) -> str:


### PR DESCRIPTION
# Overview

On April 9th, the Github traffic API we use to get all metrics returned the following JSON:

> {"message": "The Traffic API is temporarily unavailable", "documentation_url": "https://docs.github.com/rest/metrics/traffic#get-repository-clones", "status": "503"}

The popular paths, views and popular referrers API endpoints also failed in a similar manner, as did the stars and forks endpoints.

We successfully saved these error messages as JSON files in the archiving script, resulting in an error when the `load_metrics` action [ran on Monday](https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/14439775472) and attempted to actually ingest this data for all of our partitioned metrics. This is an undesirable effect - we should raise an error when the API returns this response, failing the archive action so we aren't silently saving bad data.

I manually deleted this incorrect record from the cloud bucket for each partitioned metric and given the 2-week window of data we haven't lost any data points for clones or views, but did lose a day of data for popular paths and popular referrers. We should prevent this from being able to occur!

What did you change in this PR?
Raise an error if the Github API returns a bad status or the JSON response has a status code other than 200. There isn't as far as I can see any status codes in successful JSON responses, but I include 200 as a possible response in case this changes in the future.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `load_metrics` on this branch successfully: https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/14475496009/job/40600038582

# To-do list

```[tasklist]
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have
```
