### PR TITLE
Fix response.status to response.status_code

### DIFF
--- a/src/usage_metrics/scripts/save_github_metrics.py
+++ b/src/usage_metrics/scripts/save_github_metrics.py
@@ -43,21 +43,23 @@ def get_biweekly_metrics(owner: str, repo: str, token: str, metric: str) -> str:
 
     # If "status" returned by API or noted in JSON, it's always an error. If the
     # status code is bad or the JSON itself contains a status, raise an error.
-    if response.status_code != 200:
+    if (response.status_code != 200) or (
         # Can be a dictionary or a list of dictionaries, so we have to check both cases
-        if (
+        (
             isinstance(response_json, dict)
             and response_json.get("status") not in [None, "200"]
-        ) or (
+        )
+        or (
             isinstance(response_json, list)
             and any(
                 resp_dict.get("status") not in [None, "200"]
                 for resp_dict in response_json
             )
-        ):
-            raise ValueError(
-                f"Github API for {metric} returning message {response_json}. See URL {url}"
-            )
+        )
+    ):
+        raise ValueError(
+            f"Github API for {metric} returning message {response_json}. See URL {url}"
+        )
     return json.dumps(response_json)
 
 


### PR DESCRIPTION
# Overview

What problem does this address?
In #266 I introduced an error into `save_github_metrics.py`, using `response.status` instead of response.status_code`. In the process of fixing this, I learned that the Github API can return either a dictionary or a list of dictionaries, requiring an update to the IF condition written in #266.

What did you change in this PR?
Updated `status` to `status_code` and updated the if condition to handle lists of dictionaries.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `save_daily_metrics` against this branch.

# To-do list

```[tasklist]
- [ ] is there a more elegant way to handle this IF condition? It's functional but ugly.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
