### PR TITLE
Debug ETL: Update STEO, preempt switch to eiaapi

### DIFF
--- a/src/usage_metrics/core/zenodo.py
+++ b/src/usage_metrics/core/zenodo.py
@@ -82,7 +82,7 @@ def core_zenodo_logs(
     dataset_slugs = {
         "10723220": "ipi_presentation",
         "10838487": "eiaaeo",
-        "7067366": "eia_bulk_elec",
+        "7067366": "eiaapi",
         "7682357": "eia176",
         "10607836": "eia191",
         "10607838": "eia757a",
@@ -126,6 +126,7 @@ def core_zenodo_logs(
         "14783267": "eiarecs",
         "14783043": "epamats",
         "14888356": "nrelsiting",
+        "15312754": "eiasteo",
     }
 
     missed_mapping = df[


### PR DESCRIPTION
# Overview

What problem does this address?

Fix the run failure: https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/14831164143

What did you change in this PR?

- Add EIA STEO mapping
- Preempt the renaming of `eia_bulk_elec` to `eiaapi` in https://github.com/catalyst-cooperative/pudl-archiver/pull/637

# Testing

How did you make sure this worked? How can a reviewer verify this?
https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/14837168759

# To-do list

```[tasklist]
- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have
```
