### PR TITLE
add missing slug names

### DIFF
--- a/src/usage_metrics/core/zenodo.py
+++ b/src/usage_metrics/core/zenodo.py
@@ -128,6 +128,13 @@ def core_zenodo_logs(
         "14783043": "epamats",
         "14888356": "nrelsiting",
         "15312754": "eiasteo",
+        "10086108": "ferceqr",  # this one is manually compiled...
+        "2825634": "csvconf4_presentation",
+        "3677547": "ferc1_old",
+        "4127048": "censusdp1tract",
+        "4739559": "csvconf6_presentation",
+        "5348395": "hourly_demand_by_state",
+        "4127054": "epacems_old",
     }
 
     missed_mapping = df[

--- a/src/usage_metrics/core/zenodo.py
+++ b/src/usage_metrics/core/zenodo.py
@@ -128,11 +128,11 @@ def core_zenodo_logs(
         "14783043": "epamats",
         "14888356": "nrelsiting",
         "15312754": "eiasteo",
-        "10086108": "ferceqr",  # this one is manually compiled...
-        "2825634": "csvconf4_presentation",
-        "3677547": "ferc1_old",
+        "10086108": "ferceqr",
+        "2825634": "csv_conf_2019_pudl",
+        "3677547": "ferc1_sqlite",
         "4127048": "censusdp1tract",
-        "4739559": "csvconf6_presentation",
+        "4739559": "csv_conf_2021_pudl",
         "5348395": "hourly_demand_by_state",
         "4127054": "epacems_old",
     }


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview
fixing this failure: https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/16110508575/job/45452904195

introduced via #303

# Testing

How did you make sure this worked? How can a reviewer verify this?

- i ran the raw and core logs locally, then looked at them to see if the new slugs come through
```python
from usage_metrics.etl import defs

asset_key = "core_zenodo_logs"
partition_key = "2025-06-29"
with defs.get_asset_value_loader() as loader:
    df = loader.load_asset_value(asset_key, partition_key=partition_key)

print(len(df.dataset_slug.unique()))
print(df.dataset_slug.unique())

53
['nrelatb' 'nrelsts' 'vcerare' 'censuspep' 'ferc_xbrl_extractor' 'ferc60'
 'ferc2' 'ferc714' 'eiaaeo' 'pudl_code' 'pudl_data_release' 'eia860m'
 'eiaapi' 'eia191' 'epamats' 'eiarecs' 'phmsagas' 'ferc1' 'eia860' 'ferc6'
 'epacems' 'eiasteo' 'eia923' 'mshamines' 'eia930' 'ferceqr' 'eia757a'
 'ipi_presentation' 'csv_conf_2024_coops' 'csv_conf_2024_pudl' 'naps2024'
 'gridpathatk' 'eiawater' 'eia176' 'usgsuspvdb' 'doeiraec' 'doelead'
 'eianems' 'nrelefs' 'usgswtdb' 'epacamd_eia' 'eiacbecs' 'nrelsiting'
 'nrelss' 'epaegrid' 'epapcap' 'eia861' 'csv_conf_2019_pudl'
 'ferc1_sqlite' 'censusdp1tract' 'csv_conf_2021_pudl'
 'hourly_demand_by_state' 'epacems_old']
```

# To-do list

- [ ] add other TODO items here if necessary! questions that need to answered, decisions that need to be made, tests that need to be run, etc.
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

