### PR TITLE
Fix deduplication in S3

### DIFF
--- a/src/usage_metrics/core/s3.py
+++ b/src/usage_metrics/core/s3.py
@@ -74,6 +74,17 @@ def core_s3_logs(
     )  # Mask null IPs
     geocoded_df = geocode_ips(raw_s3_logs)
 
+    # Drop unnecessary geocoding columns
+    geocoded_df = geocoded_df.drop(
+        columns=[
+            "remote_ip_country_flag",
+            "remote_ip_country_flag_url",
+            "remote_ip_country_currency",
+            "remote_ip_continent",
+            "remote_ip_isEU",
+        ]
+    )
+
     # Convert string to datetime using Pandas
     format_string = "[%d/%b/%Y:%H:%M:%S %z]"
     geocoded_df["time"] = pd.to_datetime(geocoded_df.time, format=format_string)
@@ -102,22 +113,11 @@ def core_s3_logs(
         geocoded_df.request_id + "_" + geocoded_df.operation + "_" + geocoded_df.key
     )
 
-    # Drop entirely duplicate rows
+    # Make sure all completely duplicate rows dropped
     geocoded_df = geocoded_df.drop_duplicates()
 
     geocoded_df = geocoded_df.set_index("id")
     assert geocoded_df.index.is_unique
-
-    # Drop unnecessary geocoding columns
-    geocoded_df = geocoded_df.drop(
-        columns=[
-            "remote_ip_country_flag",
-            "remote_ip_country_flag_url",
-            "remote_ip_country_currency",
-            "remote_ip_continent",
-            "remote_ip_isEU",
-        ]
-    )
 
     context.log.info(f"Saving to {os.getenv('METRICS_PROD_ENV', 'local')} environment.")
 


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

Closes #313 

What problem does this address?
Right now two S3 rows are getting marked as non-duplicates during the `drop_duplicates()` step, but they are in fact duplicates once all the dtypes etc. have been converted and extraneous rows have been dropped. This causes a non-unique index.

What did you change in this PR?
Move the `drop_duplicates()` step later in the transformation process.

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

- [x] Actually test table locally
- [ ] Update prod DB once reviewed
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [x] Review the PR yourself and call out any questions or issues you have

