### PR TITLE
Debug Zenodo column name change

### DIFF
--- a/src/usage_metrics/core/zenodo.py
+++ b/src/usage_metrics/core/zenodo.py
@@ -54,6 +54,7 @@ def core_zenodo_logs(
             "stats.version_views": "version_views",
             "stats.version_unique_views": "version_unique_views",
             "swh.swhid": "software_hash_id",
+            "swh": "software_hash_id",  # Updated in mid October 2025
         }
     )
     # Drop columns


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?
The [load metrics run](https://github.com/catalyst-cooperative/pudl-usage-metrics/actions/runs/18694274781) currently fails for two reasons:

- A yet as un-debugged problem with a tmpfile not being found, which only occurs in GHA. This is out of scope for this PR.
- A change in the column name Zenodo uses to refer to the new software hash field, which occurs locally

What did you change in this PR?
- Added `swh` to the mapping to `software_hash_id` to catch the new raw column name from Zenodo

# Testing

How did you make sure this worked? How can a reviewer verify this?

# To-do list

- [ ] Debug the tempfile failure (not observed locally with a set data directory)
- [ ] Update relevant documentation - like comments, docstrings, README, release notes, etc.
- [ ] Review the PR yourself and call out any questions or issues you have

