### PR TITLE
Move to using daily partitions, update GHA frequency

### DIFF
--- a/.github/workflows/load-metrics.yml
+++ b/.github/workflows/load-metrics.yml
@@ -8,7 +8,7 @@ on:
         required: false
 
   schedule:
-    - cron: "14 7 * * 1" # Every Monday at 7:14 AM UTC
+    - cron: "14 7 * * *" # Every day at 7:14 AM UTC
 
 env:
   METRICS_PROD_ENV: "prod"
@@ -43,7 +43,7 @@ jobs:
         with:
           version: ">= 363.0.0"
 
-      - name: Run ETL on the latest full week of data
+      - name: Run ETL on the latest day's data
         id: load-data
         env:
           IPINFO_TOKEN: ${{ secrets.IPINFO_TOKEN }}

--- a/src/usage_metrics/core/eel_hole.py
+++ b/src/usage_metrics/core/eel_hole.py
@@ -10,7 +10,7 @@ from urllib.parse import urlsplit
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 from pydantic import BaseModel, BeforeValidator, field_validator, model_validator
@@ -158,7 +158,7 @@ class EelHoleLogs(BaseModel):
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     tags={"source": "eel_hole"},
 )
 def _core_eel_hole_logs(
@@ -303,7 +303,7 @@ def _core_eel_hole_logs(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "eel_hole"},
@@ -328,7 +328,7 @@ def core_eel_hole_log_ins(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "eel_hole"},
@@ -362,7 +362,7 @@ def core_eel_hole_searches(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "eel_hole"},
@@ -385,7 +385,7 @@ def core_eel_hole_hits(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "eel_hole"},
@@ -412,7 +412,7 @@ def core_eel_hole_previews(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "eel_hole"},
@@ -439,7 +439,7 @@ def core_eel_hole_downloads(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "eel_hole"},

--- a/src/usage_metrics/core/github_partitioned.py
+++ b/src/usage_metrics/core/github_partitioned.py
@@ -5,13 +5,13 @@ import os
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "github_partitioned"},
@@ -43,7 +43,7 @@ def core_github_popular_referrers(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "github_partitioned"},
@@ -75,7 +75,7 @@ def core_github_popular_paths(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "github_partitioned"},
@@ -128,7 +128,7 @@ def core_github_clones(
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "github_partitioned"},

--- a/src/usage_metrics/core/kaggle.py
+++ b/src/usage_metrics/core/kaggle.py
@@ -5,13 +5,13 @@ import os
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "kaggle"},

--- a/src/usage_metrics/core/s3.py
+++ b/src/usage_metrics/core/s3.py
@@ -5,7 +5,7 @@ import os
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 
@@ -13,7 +13,7 @@ from usage_metrics.helpers import geocode_ips
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "s3"},

--- a/src/usage_metrics/core/zenodo.py
+++ b/src/usage_metrics/core/zenodo.py
@@ -5,13 +5,13 @@ import os
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "zenodo"},

--- a/src/usage_metrics/out/s3.py
+++ b/src/usage_metrics/out/s3.py
@@ -3,7 +3,7 @@
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 
@@ -15,7 +15,7 @@ REQUESTERS_IGNORE = [
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     io_manager_key="parquet_manager",
     kinds={"parquet"},
     tags={"source": "s3"},

--- a/src/usage_metrics/raw/eel_hole.py
+++ b/src/usage_metrics/raw/eel_hole.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 from google.api_core.page_iterator import HTTPIterator
@@ -53,7 +53,7 @@ class EelHoleExtractor(GCSExtractor):
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     tags={"source": "eel_hole"},
 )
 def raw_eel_hole_logs(context: AssetExecutionContext) -> pd.DataFrame:

--- a/src/usage_metrics/raw/github_partitioned.py
+++ b/src/usage_metrics/raw/github_partitioned.py
@@ -13,7 +13,7 @@ import pandas as pd
 from dagster import (
     AssetExecutionContext,
     AssetsDefinition,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 from google.api_core.page_iterator import HTTPIterator
@@ -133,7 +133,7 @@ def weekly_metrics_extraction_factory(
 
     @asset(
         name=f"raw_github_{metric}",
-        partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+        partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
         tags={"source": "github_partitioned"},
     )
     def _raw_github_logs(context: AssetExecutionContext) -> pd.DataFrame:

--- a/src/usage_metrics/raw/kaggle.py
+++ b/src/usage_metrics/raw/kaggle.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 from google.api_core.page_iterator import HTTPIterator
@@ -79,7 +79,7 @@ class KaggleExtractor(GCSExtractor):
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     tags={"source": "kaggle"},
 )
 def raw_kaggle_logs(context: AssetExecutionContext) -> pd.DataFrame:

--- a/src/usage_metrics/raw/s3.py
+++ b/src/usage_metrics/raw/s3.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 from google.api_core.page_iterator import HTTPIterator
@@ -60,7 +60,7 @@ class S3Extractor(GCSExtractor):
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     tags={"source": "s3"},
 )
 def raw_s3_logs(context: AssetExecutionContext) -> pd.DataFrame:

--- a/src/usage_metrics/raw/zenodo.py
+++ b/src/usage_metrics/raw/zenodo.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import pandas as pd
 from dagster import (
     AssetExecutionContext,
-    WeeklyPartitionsDefinition,
+    DailyPartitionsDefinition,
     asset,
 )
 from google.api_core.page_iterator import HTTPIterator
@@ -99,7 +99,7 @@ class ZenodoExtractor(GCSExtractor):
 
 
 @asset(
-    partitions_def=WeeklyPartitionsDefinition(start_date="2023-08-16"),
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
     tags={"source": "zenodo"},
 )
 def raw_zenodo_logs(context: AssetExecutionContext) -> pd.DataFrame:


### PR DESCRIPTION
<!--
Resources:
* contributing guidelines: https://catalystcoop-pudl.readthedocs.io/en/latest/CONTRIBUTING.html
* code of conduct: https://catalystcoop-pudl.readthedocs.io/en/latest/code_of_conduct.html
-->
# Overview

What problem does this address?
Move from using weekly to daily partitions so we can see changes in our metrics much more quickly.

What did you change in this PR?
Updated the partitions from `WeeklyPartitionDefinition` to `DailyPartitionDefinition` and updated the cron job to run every day on the latest daily partition.

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `pixi update-local` and run the latest partition. We'll want to handle backfills for anything between the current partition end and the present date when we merge this in.

# To-do list

- [x] Review the PR yourself and call out any questions or issues you have

