### PR TITLE
Add processed out tables to S3 to improve performance, actually make data ETL run daily

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -281,6 +281,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pillow-12.1.1-py312h50c33e8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.40.0-pyh58ad624_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.40.0-py310hffdcd12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
@@ -411,7 +413,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/da/d3c94fc7c72ad9298072681ec3e8cea86949acc5c4cce4290ba21f7050a8/cachetools-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5b/4eaf81d926b65247b3ff9376f71cf3aac287b3d8af1b2a12fd2605fd8534/cloud_sql_python_connector-1.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/53/e94962c964644f75cae552ed2d8162cf0404d6e7004113777f355717f9ec/cloud_sql_python_connector-1.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/58/de64dd860e606c78ff496d48b685583d29e2049d5facaf169ee55948cd61/ipinfo-5.5.0-py3-none-any.whl
       - pypi: ./
@@ -652,6 +654,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pg8000-1.31.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pillow-12.1.1-py312h4985050_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.40.0-pyh58ad624_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/polars-runtime-32-1.40.0-py310h428a0da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
@@ -760,7 +764,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/da/d3c94fc7c72ad9298072681ec3e8cea86949acc5c4cce4290ba21f7050a8/cachetools-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5b/4eaf81d926b65247b3ff9376f71cf3aac287b3d8af1b2a12fd2605fd8534/cloud_sql_python_connector-1.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/53/e94962c964644f75cae552ed2d8162cf0404d6e7004113777f355717f9ec/cloud_sql_python_connector-1.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/58/de64dd860e606c78ff496d48b685583d29e2049d5facaf169ee55948cd61/ipinfo-5.5.0-py3-none-any.whl
       - pypi: ./
@@ -1001,6 +1005,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pg8000-1.31.5-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pillow-12.1.1-py312h4e908a4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.40.0-pyh58ad624_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.40.0-py310h216a1ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.52-pyha770c72_0.conda
@@ -1109,7 +1115,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/da/d3c94fc7c72ad9298072681ec3e8cea86949acc5c4cce4290ba21f7050a8/cachetools-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5b/4eaf81d926b65247b3ff9376f71cf3aac287b3d8af1b2a12fd2605fd8534/cloud_sql_python_connector-1.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/53/e94962c964644f75cae552ed2d8162cf0404d6e7004113777f355717f9ec/cloud_sql_python_connector-1.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/58/de64dd860e606c78ff496d48b685583d29e2049d5facaf169ee55948cd61/ipinfo-5.5.0-py3-none-any.whl
       - pypi: ./
@@ -1407,6 +1413,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.40.0-pyh58ad624_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.40.0-py310hffdcd12_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/prometheus-cpp-1.3.0-ha5d0236_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
@@ -1552,7 +1560,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/da/d3c94fc7c72ad9298072681ec3e8cea86949acc5c4cce4290ba21f7050a8/cachetools-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5b/4eaf81d926b65247b3ff9376f71cf3aac287b3d8af1b2a12fd2605fd8534/cloud_sql_python_connector-1.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/53/e94962c964644f75cae552ed2d8162cf0404d6e7004113777f355717f9ec/cloud_sql_python_connector-1.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/58/de64dd860e606c78ff496d48b685583d29e2049d5facaf169ee55948cd61/ipinfo-5.5.0-py3-none-any.whl
       - pypi: ./
@@ -1806,6 +1814,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.40.0-pyh58ad624_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/polars-runtime-32-1.40.0-py310h428a0da_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/prometheus-cpp-1.3.0-h7802330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
@@ -1929,7 +1939,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/da/d3c94fc7c72ad9298072681ec3e8cea86949acc5c4cce4290ba21f7050a8/cachetools-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5b/4eaf81d926b65247b3ff9376f71cf3aac287b3d8af1b2a12fd2605fd8534/cloud_sql_python_connector-1.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/53/e94962c964644f75cae552ed2d8162cf0404d6e7004113777f355717f9ec/cloud_sql_python_connector-1.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/58/de64dd860e606c78ff496d48b685583d29e2049d5facaf169ee55948cd61/ipinfo-5.5.0-py3-none-any.whl
       - pypi: ./
@@ -2183,6 +2193,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pip-26.0.1-pyh8b19718_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/platformdirs-4.9.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pluggy-1.6.0-pyhf9edf01_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.40.0-pyh58ad624_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.40.0-py310h216a1ac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/prometheus-cpp-1.3.0-h0967b3e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/prometheus_client-0.24.1-pyhd8ed1ab_0.conda
@@ -2306,7 +2318,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
       - pypi: https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/da/d3c94fc7c72ad9298072681ec3e8cea86949acc5c4cce4290ba21f7050a8/cachetools-4.2.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/56/5b/4eaf81d926b65247b3ff9376f71cf3aac287b3d8af1b2a12fd2605fd8534/cloud_sql_python_connector-1.20.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d0/53/e94962c964644f75cae552ed2d8162cf0404d6e7004113777f355717f9ec/cloud_sql_python_connector-1.20.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/6e/58/de64dd860e606c78ff496d48b685583d29e2049d5facaf169ee55948cd61/ipinfo-5.5.0-py3-none-any.whl
       - pypi: ./
@@ -3896,10 +3908,10 @@ packages:
   - pkg:pypi/click?source=hash-mapping
   size: 97676
   timestamp: 1764518652276
-- pypi: https://files.pythonhosted.org/packages/56/5b/4eaf81d926b65247b3ff9376f71cf3aac287b3d8af1b2a12fd2605fd8534/cloud_sql_python_connector-1.20.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/d0/53/e94962c964644f75cae552ed2d8162cf0404d6e7004113777f355717f9ec/cloud_sql_python_connector-1.20.2-py3-none-any.whl
   name: cloud-sql-python-connector
-  version: 1.20.1
-  sha256: c00f9d81205eb658fe06f9f353e00646eb3f55d2d86de01dc1222eec1f5f2fc9
+  version: 1.20.2
+  sha256: cbd55bf58cbd5bea8e44c5768bcecc18d4ab2bc490150d90620b3fdb518d1063
   requires_dist:
   - aiofiles
   - aiohttp
@@ -9780,6 +9792,88 @@ packages:
   - pkg:pypi/pluggy?source=compressed-mapping
   size: 25877
   timestamp: 1764896838868
+- conda: https://conda.anaconda.org/conda-forge/noarch/polars-1.40.0-pyh58ad624_0.conda
+  sha256: c3da6a82313020b690b556df64062aaa440f26ef5ce5ced6e7a5f5343061893e
+  md5: fd16be490f5403adfbf27dd4901bbe34
+  depends:
+  - polars-runtime-32 ==1.40.0
+  - python >=3.10
+  - python
+  constrains:
+  - numpy >=1.16.0
+  - pyarrow >=7.0.0
+  - fastexcel >=0.9
+  - openpyxl >=3.0.0
+  - xlsx2csv >=0.8.0
+  - connectorx >=0.3.2
+  - deltalake >=1.0.0
+  - pyiceberg >=0.7.1
+  - altair >=5.4.0
+  - great_tables >=0.8.0
+  - polars-runtime-32 ==1.40.0
+  - polars-runtime-64 ==1.40.0
+  - polars-runtime-compat ==1.40.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/polars?source=hash-mapping
+  size: 536257
+  timestamp: 1776563396053
+- conda: https://conda.anaconda.org/conda-forge/linux-64/polars-runtime-32-1.40.0-py310hffdcd12_0.conda
+  noarch: python
+  sha256: 4f270fd8e73b29052cbed427cf82bcdf6ff70d8b47db30250a1ea5d250a3a039
+  md5: 8eacf9ff4d4e1ca1b52f8f3ba3e0c993
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=14
+  - libgcc >=14
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/polars-runtime-32?source=hash-mapping
+  size: 41995503
+  timestamp: 1776563396053
+- conda: https://conda.anaconda.org/conda-forge/osx-64/polars-runtime-32-1.40.0-py310h428a0da_0.conda
+  noarch: python
+  sha256: 36632ce86ef2c33bc21022a5cf59264e11b2ab56b59506020c4e3bd4856b5e8a
+  md5: 4280f8d9b94239558f0046c23fd95632
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __osx >=10.13
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/polars-runtime-32?source=hash-mapping
+  size: 40882172
+  timestamp: 1776563288897
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/polars-runtime-32-1.40.0-py310h216a1ac_0.conda
+  noarch: python
+  sha256: 6a827be3c25fe0044a94a2437fe038a0af6ab65b3d90d3cbd513a83c9b69af39
+  md5: 1ebdb204ac27d15be71ff527cf934454
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - _python_abi3_support 1.*
+  - cpython >=3.10
+  constrains:
+  - __osx >=11.0
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/polars-runtime-32?source=hash-mapping
+  size: 35948230
+  timestamp: 1776563261192
 - conda: https://conda.anaconda.org/conda-forge/noarch/pre-commit-4.5.1-pyha770c72_0.conda
   sha256: 5b81b7516d4baf43d0c185896b245fa7384b25dc5615e7baa504b7fa4e07b706
   md5: 7f3ac694319c7eaf81a0325d6405e974
@@ -10118,9 +10212,10 @@ packages:
 - pypi: ./
   name: pudl-usage-metrics
   version: 0.1.0
-  sha256: c8c683429ddf11fbf033fbfe53cef6e4d4814e0123f1ccc0f1aa13d61950228c
+  sha256: bdbf0694659bab30b3d86f9a03e0c56ec17001226e2c6c663c47e9338d219599
   requires_dist:
   - cloud-sql-python-connector[pg8000]>=1.11.0
+  - polars>=1.40.0
   requires_python: '>=3.12,<3.13'
 - conda: https://conda.anaconda.org/conda-forge/noarch/pure_eval-0.2.3-pyhd8ed1ab_1.conda
   sha256: 71bd24600d14bb171a6321d523486f6a06f855e75e547fa0cb2a0953b02047f0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,10 @@ requires-python = ">=3.12,<3.13"
 
 # managed by pixi; see tool.pixi.dependencies below
 # cloud-sql-python-connector is configured here because we need extras [pg8000].
-dependencies = ["cloud-sql-python-connector[pg8000]>=1.11.0"]
+dependencies = [
+    "cloud-sql-python-connector[pg8000]>=1.11.0",
+    "polars>=1.40.0",
+]
 
 classifiers = [
     "Development Status :: 3 - Alpha",
@@ -54,6 +57,7 @@ pg8000 = ">=1.31.1"
 google-cloud-storage = ">=2.17"
 kaggle = ">=1.6.3"
 s3fs = ">=2025.10.0"
+polars = ">=1.40.0,<2"
 
 [tool.pixi.pypi-dependencies]
 # Install the local package in editable mode. Assume dependencies are specified either

--- a/src/usage_metrics/models.py
+++ b/src/usage_metrics/models.py
@@ -576,7 +576,7 @@ out_s3_daily_summary_by_db = Table(
     Column(
         "database",
         String,
-        comment="Parquet files are lumped into one parquet_file record.",
+        comment="Which type of database the record is accessing (e.g., pudl.sqlite, ferc1.duckdb). Parquet files are lumped into one parquet_file record.",
     ),
     Column("version", String),
     Column(

--- a/src/usage_metrics/models.py
+++ b/src/usage_metrics/models.py
@@ -473,6 +473,96 @@ out_s3_logs = Table(
     Column("partition_key", String),
 )
 
+out_s3_daily_summary_by_table = Table(
+    "out_s3_daily_summary_by_table",
+    usage_metrics_metadata,
+    Column("id", String, primary_key=True, comment="A unique ID for each log."),
+    # Query information
+    Column(
+        "time",
+        DateTime,
+        comment="The day for which metrics are reported.",
+    ),
+    Column("table", String),
+    Column("version", String),
+    Column(
+        "usage_type",
+        String,
+        comment=(
+            "The type of usage activity. Distinguishes between requests made through DuckDB via the eel hole (eel_hole_duckdb), by clicking the download Parquet button in the eel hole (eel_hole_link), by clicking a download link from the docs, or other direct S3 activity."
+        ),
+    ),
+    Column(
+        "megabytes_sent",
+        Float,
+        comment="The total size of the object in question in megabytes.",
+    ),
+    Column(
+        "normalized_file_downloads",
+        Float,
+        comment="The proportion of the file that is downloaded (0 to 1).",
+    ),
+    Column(
+        "request_count",
+        Integer,
+        comment="The number of requests made per table, usage method and day.",
+    ),
+    Column("partition_key", String),
+)
+
+out_s3_daily_summary_by_user = Table(
+    "out_s3_daily_summary_by_user",
+    usage_metrics_metadata,
+    Column("id", String, primary_key=True, comment="A unique ID for each log."),
+    # Query information
+    Column(
+        "time",
+        DateTime,
+        comment="The day for which metrics are reported.",
+    ),
+    Column("table", String),
+    Column("version", String),
+    Column(
+        "usage_type",
+        String,
+        comment=(
+            "The type of usage activity. Distinguishes between requests made through DuckDB via the eel hole (eel_hole_duckdb), by clicking the download Parquet button in the eel hole (eel_hole_link), by clicking a download link from the docs, or other direct S3 activity."
+        ),
+    ),
+    # IP location
+    Column(
+        "remote_ip",
+        String,
+        comment="The apparent IP address of the requester. Intermediate proxies and firewalls might obscure the actual IP address of the machine that's making the request.",
+    ),
+    Column(
+        "remote_ip_org",
+        String,
+        comment="IP Organization name, as determined by IPInfo.",
+    ),
+    Column(
+        "remote_ip_country_name",
+        String,
+        comment="Country where the IP is located, as determined by IPInfo.",
+    ),
+    Column(
+        "megabytes_sent",
+        Float,
+        comment="The total size of the object in question in megabytes.",
+    ),
+    Column(
+        "normalized_file_downloads",
+        Float,
+        comment="The proportion of the file that is downloaded (0 to 1).",
+    ),
+    Column(
+        "request_count",
+        Integer,
+        comment="The number of requests made per table, usage method and day.",
+    ),
+    Column("partition_key", String),
+)
+
 core_kaggle_logs = Table(
     "core_kaggle_logs",
     usage_metrics_metadata,

--- a/src/usage_metrics/models.py
+++ b/src/usage_metrics/models.py
@@ -563,6 +563,47 @@ out_s3_daily_summary_by_user = Table(
     Column("partition_key", String),
 )
 
+out_s3_daily_summary_by_db = Table(
+    "out_s3_daily_summary_by_db",
+    usage_metrics_metadata,
+    Column("id", String, primary_key=True, comment="A unique ID for each log."),
+    # Query information
+    Column(
+        "time",
+        DateTime,
+        comment="The day for which metrics are reported.",
+    ),
+    Column(
+        "database",
+        String,
+        comment="Parquet files are lumped into one parquet_file record.",
+    ),
+    Column("version", String),
+    Column(
+        "usage_type",
+        String,
+        comment=(
+            "The type of usage activity. Distinguishes between requests made through DuckDB via the eel hole (eel_hole_duckdb), by clicking the download Parquet button in the eel hole (eel_hole_link), by clicking a download link from the docs, or other direct S3 activity."
+        ),
+    ),
+    Column(
+        "megabytes_sent",
+        Float,
+        comment="The total size of the object in question in megabytes.",
+    ),
+    Column(
+        "normalized_file_downloads",
+        Float,
+        comment="The proportion of the file that is downloaded (0 to 1).",
+    ),
+    Column(
+        "request_count",
+        Integer,
+        comment="The number of requests made per table, usage method and day.",
+    ),
+    Column("partition_key", String),
+)
+
 core_kaggle_logs = Table(
     "core_kaggle_logs",
     usage_metrics_metadata,

--- a/src/usage_metrics/out/s3.py
+++ b/src/usage_metrics/out/s3.py
@@ -111,8 +111,8 @@ def out_s3_logs(
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
-    # io_manager_key="parquet_manager",
-    # kinds={"parquet"},
+    io_manager_key="parquet_manager",
+    kinds={"parquet"},
     tags={"source": "s3"},
 )
 def out_s3_daily_summary_by_table(
@@ -123,14 +123,42 @@ def out_s3_daily_summary_by_table(
         pl.DataFrame(out_s3_logs)
         .filter(pl.col("table").str.ends_with(".parquet"))
         .sort(["time", "table"])
-        .group_by_dynamic("time", every="1d", group_by=["usage_type", "table"])
+        .group_by_dynamic(
+            "time", every="1d", group_by=["usage_type", "table", "version"]
+        )
         .agg(
-            normalized_file_downloads=pl.col("normalized_file_downloads")
-            .sum()
-            .round(0),
+            normalized_file_downloads=pl.col("normalized_file_downloads").sum(),
             request_count=pl.col("request_uri").count().alias("request_count"),
             megabytes_sent=(pl.col("megabytes_sent").sum().round(3)),
-            unique_ips=pl.col("remote_ip").n_unique(),
+        )
+    )
+    return summary_df.to_pandas()
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
+    io_manager_key="parquet_manager",
+    kinds={"parquet"},
+    tags={"source": "s3"},
+)
+def out_s3_daily_summary_by_user(
+    out_s3_logs: pd.DataFrame,
+) -> pd.DataFrame:
+    """Get a daily summary by IP from out_s3_logs."""
+    summary_df = (
+        pl.DataFrame(out_s3_logs)
+        .filter(pl.col("table").str.ends_with(".parquet"))
+        .sort(["time", "table"])
+        .group_by_dynamic(
+            "time",
+            every="1d",
+            group_by=["remote_ip", "table", "remote_ip_org", "remote_ip_country_name"],
+        )
+        .agg(
+            normalized_file_downloads=pl.col("normalized_file_downloads").sum(),
+            request_count=pl.col("request_uri").count().alias("request_count"),
+            megabytes_sent=(pl.col("megabytes_sent").sum().round(3)),
+            usage_type=(pl.col("usage_type").mode().first()),
         )
     )
     return summary_df.to_pandas()

--- a/src/usage_metrics/out/s3.py
+++ b/src/usage_metrics/out/s3.py
@@ -1,6 +1,7 @@
 """Create outputs from S3 logs."""
 
 import pandas as pd
+import polars as pl
 from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
@@ -16,8 +17,8 @@ REQUESTERS_IGNORE = [
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
-    io_manager_key="parquet_manager",
-    kinds={"parquet"},
+    # io_manager_key="parquet_manager",
+    # kinds={"parquet"},
     tags={"source": "s3"},
 )
 def out_s3_logs(
@@ -27,7 +28,8 @@ def out_s3_logs(
     """Output daily S3 logs.
 
     Filter to GET requests, drop Catalyst and AWS traffic, and add version/table
-    columns.
+    columns. Also drop old EPACEMS files, JSON files, and traffic where no
+    data is sent.
     """
     context.log.info(f"Processing data for the week of {context.partition_key}")
 
@@ -39,12 +41,33 @@ def out_s3_logs(
         | (core_s3_logs.operation == "REST.GET.OBJECT")
     ]
 
+    # Only keep records with data sent
+    out = out.loc[out.megabytes_sent > 0]
+
     # Drop PUDL intake, AWS Registry of Open Data Checker, and PUDL logs sync
     out = out.loc[~out.requester.isin(REQUESTERS_IGNORE)]
 
     # Add columns for tables and versions
     out[["version", "table"]] = out["key"].str.split("/", expand=True, n=1)
     out["version"] = out["version"].replace(["-", ""], pd.NA)
+
+    # Drop .js files and old accidental hourly emissions data
+    out = out.loc[
+        ~(
+            out.table.str.endswith(".js")
+            | out.table.str.startswith("hourly_emissions_epacems/")
+        )
+    ]
+
+    # Drop logfiles
+    out = out[~out.table.str.endswith((".log", ".csv", "env"))]  # Clean up cruft
+
+    # Treat different zips as same format
+    out = out.replace(["sqlite.gz", "sqlite.zip"], ["sqlite", "sqlite"], regex=True)
+
+    out.loc[out.table.str.contains("hourly_emissions"), "table"] = (
+        "core_epacems__hourly_emissions.parquet"  # We renamed this table
+    )
 
     # Categorize usage types
     # Only after the eel-hole bucket was created on Nov 24th.
@@ -84,3 +107,30 @@ def out_s3_logs(
     )
 
     return out
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
+    # io_manager_key="parquet_manager",
+    # kinds={"parquet"},
+    tags={"source": "s3"},
+)
+def out_s3_daily_summary_by_table(
+    out_s3_logs: pd.DataFrame,
+) -> pd.DataFrame:
+    """Get a daily summary by table from out_s3_logs."""
+    summary_df = (
+        pl.DataFrame(out_s3_logs)
+        .filter(pl.col("table").str.ends_with(".parquet"))
+        .sort(["time", "table"])
+        .group_by_dynamic("time", every="1d", group_by=["usage_type", "table"])
+        .agg(
+            normalized_file_downloads=pl.col("normalized_file_downloads")
+            .sum()
+            .round(0),
+            request_count=pl.col("request_uri").count().alias("request_count"),
+            megabytes_sent=(pl.col("megabytes_sent").sum().round(3)),
+            unique_ips=pl.col("remote_ip").n_unique(),
+        )
+    )
+    return summary_df.to_pandas()

--- a/src/usage_metrics/out/s3.py
+++ b/src/usage_metrics/out/s3.py
@@ -162,3 +162,35 @@ def out_s3_daily_summary_by_user(
         )
     )
     return summary_df.to_pandas()
+
+
+@asset(
+    partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
+    io_manager_key="parquet_manager",
+    kinds={"parquet"},
+    tags={"source": "s3"},
+)
+def out_s3_daily_summary_by_db(
+    out_s3_logs: pd.DataFrame,
+) -> pd.DataFrame:
+    """Get a daily summary by database from out_s3_logs."""
+    summary_df = (
+        pl.DataFrame(out_s3_logs)
+        .with_columns(
+            pl.when(pl.col("table").str.contains(".parquet"))
+            .then(pl.lit("parquet_file"))
+            .otherwise(pl.col("table"))
+            .alias("database")
+        )
+        .filter(~pl.col("table").str.ends_with("/"))  # Drop folders
+        .sort(["time", "database"])
+        .group_by_dynamic(
+            "time", every="1d", group_by=["usage_type", "database", "version"]
+        )
+        .agg(
+            normalized_file_downloads=pl.col("normalized_file_downloads").sum(),
+            request_count=pl.col("request_uri").count().alias("request_count"),
+            megabytes_sent=(pl.col("megabytes_sent").sum().round(3)),
+        )
+    )
+    return summary_df.to_pandas()

--- a/src/usage_metrics/out/s3.py
+++ b/src/usage_metrics/out/s3.py
@@ -17,8 +17,6 @@ REQUESTERS_IGNORE = [
 
 @asset(
     partitions_def=DailyPartitionsDefinition(start_date="2023-08-16"),
-    # io_manager_key="parquet_manager",
-    # kinds={"parquet"},
     tags={"source": "s3"},
 )
 def out_s3_logs(

--- a/src/usage_metrics/raw/eel_hole.py
+++ b/src/usage_metrics/raw/eel_hole.py
@@ -1,5 +1,6 @@
 """Extract data from PUDL Viewer (aka "eel hole") logs."""
 
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -35,15 +36,14 @@ class EelHoleExtractor(GCSExtractor):
         Returns:
             A list of blobs to be downloaded.
         """
-        week_start_date_str = context.partition_key
-        week_date_range = pd.date_range(start=week_start_date_str, periods=7, freq="D")
-        partition_dates = tuple(week_date_range.strftime("%Y/%m/%d"))
-        file_name_prefixes = tuple(
-            f"run.googleapis.com/stdout/{date}" for date in partition_dates
+        day_start_date_str = context.partition_key
+        partition_date = datetime.strptime(day_start_date_str, "%Y-%m-%d").strftime(
+            "%Y/%m/%d"
         )
-        blobs = [blob for blob in blobs if blob.name.startswith(file_name_prefixes)]
+        file_name_prefix = f"run.googleapis.com/stdout/{partition_date}"
+        blobs = [blob for blob in blobs if blob.name.startswith(file_name_prefix)]
         context.log.info(
-            f"Extracting {len(blobs)} eel-hole logs for week of {context.partition_key}."
+            f"Extracting {len(blobs)} eel-hole logs for {context.partition_key}."
         )
         return blobs
 

--- a/src/usage_metrics/raw/github_partitioned.py
+++ b/src/usage_metrics/raw/github_partitioned.py
@@ -6,6 +6,7 @@ querying the Github API.
 
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -21,9 +22,9 @@ from google.cloud import storage
 
 from usage_metrics.raw.extract import GCSExtractor
 
-WEEKLY_METRIC_TYPES = ["clones", "popular_paths", "popular_referrers", "views"]
+DAILY_METRIC_TYPES = ["clones", "popular_paths", "popular_referrers", "views"]
 CUMULATIVE_METRIC_TYPES = ["stargazers", "forks"]
-GITHUB_METRIC_TYPES = WEEKLY_METRIC_TYPES + CUMULATIVE_METRIC_TYPES
+GITHUB_METRIC_TYPES = DAILY_METRIC_TYPES + CUMULATIVE_METRIC_TYPES
 
 
 class GithubExtractor(GCSExtractor):
@@ -52,16 +53,13 @@ class GithubExtractor(GCSExtractor):
         Returns:
             A list of blobs to be downloaded.
         """
-        if self.metric in WEEKLY_METRIC_TYPES:
-            week_start_date_str = context.partition_key
-            week_date_range = pd.date_range(
-                start=week_start_date_str, periods=7, freq="D"
+        if self.metric in DAILY_METRIC_TYPES:
+            day_start_date_str = context.partition_key
+            partition_date = datetime.strptime(day_start_date_str, "%Y-%m-%d").strftime(
+                "%Y-%m-%d"
             )
-            partition_dates = tuple(week_date_range.strftime("%Y-%m-%d"))
-            file_name_prefixes = tuple(
-                f"github/{self.metric}/{date}.json" for date in partition_dates
-            )
-            blobs = [blob for blob in blobs if blob.name in file_name_prefixes]
+            file_name = f"github/{self.metric}/{partition_date}.json"
+            blobs = [blob for blob in blobs if blob.name == file_name]
         else:
             blobs = [
                 blob for blob in blobs if blob.name.startswith(f"github/{self.metric}/")
@@ -126,10 +124,10 @@ class GithubExtractor(GCSExtractor):
         return gh_df
 
 
-def weekly_metrics_extraction_factory(
-    metric: Literal[*WEEKLY_METRIC_TYPES],
+def daily_metrics_extraction_factory(
+    metric: Literal[*DAILY_METRIC_TYPES],
 ) -> AssetsDefinition:
-    """Create Dagster asset for each weekly-reported metric."""
+    """Create Dagster asset for each daily-reported metric."""
 
     @asset(
         name=f"raw_github_{metric}",
@@ -137,12 +135,12 @@ def weekly_metrics_extraction_factory(
         tags={"source": "github_partitioned"},
     )
     def _raw_github_logs(context: AssetExecutionContext) -> pd.DataFrame:
-        """Extract Github logs from daily files and return one weekly DataFrame."""
+        """Extract Github logs from daily files and return one daily DataFrame."""
         return GithubExtractor(metric=metric).extract(context)
 
     return _raw_github_logs
 
 
 raw_github_partitioned_assets = [
-    weekly_metrics_extraction_factory(metric) for metric in WEEKLY_METRIC_TYPES
+    daily_metrics_extraction_factory(metric) for metric in DAILY_METRIC_TYPES
 ]

--- a/src/usage_metrics/raw/kaggle.py
+++ b/src/usage_metrics/raw/kaggle.py
@@ -1,6 +1,7 @@
 """Extract data from Kaggle logs."""
 
 import json
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -36,12 +37,13 @@ class KaggleExtractor(GCSExtractor):
         Returns:
             A list of blobs to be downloaded.
         """
-        week_start_date_str = context.partition_key
-        week_date_range = pd.date_range(start=week_start_date_str, periods=7, freq="D")
-        partition_dates = tuple(week_date_range.strftime("%Y-%m-%d"))
-        file_name_prefixes = tuple(f"kaggle/{date}.json" for date in partition_dates)
+        day_start_date_str = context.partition_key
+        partition_date = datetime.strptime(day_start_date_str, "%Y-%m-%d").strftime(
+            "%Y-%m-%d"
+        )
+        file_name_prefix = f"kaggle/{partition_date}.json"
 
-        blobs = [blob for blob in blobs if blob.name in file_name_prefixes]
+        blobs = [blob for blob in blobs if blob.name == file_name_prefix]
         return blobs
 
     def load_file(

--- a/src/usage_metrics/raw/s3.py
+++ b/src/usage_metrics/raw/s3.py
@@ -29,6 +29,13 @@ class S3Extractor(GCSExtractor):
     ) -> list[storage.Blob]:
         """From all possible files in a bucket, filter to include relevant ones.
 
+        Note that the timestamp on the S3 file name corresponds to the end of the window
+        in which the logs were produced, meaning that logs can sometimes contain data
+        from more than one day. We read these records in based on the file name
+        and use the time column as the referent timestamp, so this can look unusual in
+        the context of examining a single partition but does not cause any issues in
+        the overall complete timeseries analysis.
+
         Args:
             context: The Dagster asset execution context
             blobs: the list of all file blobs in the bucket, returned by bucket.list_blobs()

--- a/src/usage_metrics/raw/s3.py
+++ b/src/usage_metrics/raw/s3.py
@@ -1,5 +1,6 @@
 """Extract data from S3 logs."""
 
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -35,10 +36,11 @@ class S3Extractor(GCSExtractor):
         Returns:
             A list of blobs to be downloaded.
         """
-        week_start_date_str = context.partition_key
-        week_date_range = pd.date_range(start=week_start_date_str, periods=7, freq="D")
-        partition_dates = tuple(week_date_range.strftime("%Y-%m-%d"))
-        return [blob for blob in blobs if blob.name.startswith(partition_dates)]
+        day_start_date_str = context.partition_key
+        partition_date = datetime.strptime(day_start_date_str, "%Y-%m-%d").strftime(
+            "%Y-%m-%d"
+        )
+        return [blob for blob in blobs if blob.name.startswith(partition_date)]
 
     def load_file(self, file_path: Path) -> pd.DataFrame:
         """Read in file as dataframe."""


### PR DESCRIPTION
# Overview

Closes #444 and fixes error missed in #442 

What problem does this address?
- Current partitions are daily, but the extraction is still grabbing weekly data slices
- We do way too much processing in the S3 notebook, leading to major performance issues

What did you change in this PR?
- Actually grab daily slices of data for each dataset's ETL
- Create two daily datasets, one for table-level data and one for user-level data. These feed directly into the S3 notebook for further aggregation and manipulation, improving performance.
- Stop writing `out_s3_logs` to parquet to save on cloud storage

# Testing

How did you make sure this worked? How can a reviewer verify this?
Run `pixi run update-local` and `pixi run update-prod`.

# To-do list
- [x] Review the PR yourself and call out any questions or issues you have

